### PR TITLE
Create docker and singularity containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,8 +21,10 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 
 # Install octo/SimplerEnv python requirements
 RUN wget https://raw.githubusercontent.com/simpler-env/SimplerEnv/refs/heads/main/requirements_full_install.txt \
+    wget https://raw.githubusercontent.com/simpler-env/ManiSkill2_real2sim/cd45dd27dc6bb26d048cb6570cdab4e3f935cc37/requirements.txt \
     && pip install tensorflow==2.15.0 \
     && pip install -r requirements_full_install.txt && rm requirements_full_install.txt \
+    && pip install -r requirements.txt && rm requirements.txt \
     && pip install tensorflow[and-cuda]==2.15.1 \
     && pip install git+https://github.com/nathanrooy/simulated-annealing \
     && pip install numpy==1.24.4 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+
+WORKDIR /project
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV NVIDIA_DRIVER_CAPABILITIES=all
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    wget \
+    python3-pip \
+    python3-dev \
+    python-is-python3 \
+    git \
+    ffmpeg \
+    libnvidia-gl-560 \
+    libvulkan1 \
+    vulkan-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install octo/SimplerEnv python requirements
+RUN wget https://raw.githubusercontent.com/simpler-env/SimplerEnv/refs/heads/main/requirements_full_install.txt \
+    && pip install tensorflow==2.15.0 \
+    && pip install -r requirements_full_install.txt && rm requirements_full_install.txt \
+    && pip install tensorflow[and-cuda]==2.15.1 \
+    && pip install git+https://github.com/nathanrooy/simulated-annealing \
+    && pip install numpy==1.24.4 \
+    && pip install --upgrade "jax[cuda11_pip]==0.4.20" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
+    && pip install debugpy
+
+# Upgrade pip so we can install SimplerEnv later
+RUN pip3 install -U pip 

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,6 +7,7 @@ Since these containers will be used for active development, the Octo and Simpler
 Additionally, the python package `debugpy` is installed that allows vscode to connect a remote debug session inside the container.
 
 ## Examples
+
 ### Docker
 
 ```
@@ -20,6 +21,22 @@ The port forwarding will be used by the debugger.
 singularity shell --nv -B <Octo path>:/project/octo -B <SimplerEnv path>:/project/SimplerEnv <image_name>
 ```
 There is no network isolation in Singularity, so there is no need to map any port.
+
+### Note
+ After mounting the code directories, they still have to be installed via:
+```bash
+pip install -e /project/octo
+pip install -e /project/SimplerEnv/ManiSkill2_real2sim
+pip install -e /project/SimplerEnv
+``` 
+Or you can automate this by using `singularity exec` and a bash file:
+```bash
+#!/bin/bash
+pip install -e /project/octo
+pip install -e /project/SimplerEnv/ManiSkill2_real2sim
+pip install -e /project/SimplerEnv
+python /project/octo/examples/02_finetune_new_observation_action.py --pretrained_path=hf://rail-berkeley/octo-small --data_dir=/project/aloha_sim_dataset --save_dir=/project/checkpoints
+```
 
 ## Debugging
 If you are trying to debug a file, use the `debugpy` package to start a session that vscode can connect to:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,57 @@
+# Docker/Singularity image definitions
+
+Building on the `nvidia/cuda:11.8.0` docker image, we install the vulkan library and all the python dependencies for Octo and SimplerEnv.
+
+Since these containers will be used for active development, the Octo and SimplerEnv packages should be mounted and installed.
+
+Additionally, the python package `debugpy` is installed that allows vscode to connect a remote debug session inside the container.
+
+## Examples
+### Docker
+
+```
+docker run -v <Octo path>:/project/octo -v <SimplerEnv path>:/project/SimplerEnv -p 5678:5678 --gpus all --rm -it <image_name>
+```
+The port forwarding will be used by the debugger.
+
+### Singulartiy
+
+```
+singularity shell --nv -B <Octo path>:/project/octo -B <SimplerEnv path>:/project/SimplerEnv <image_name>
+```
+There is no network isolation in Singularity, so there is no need to map any port.
+
+## Debugging
+If you are trying to debug a file, use the `debugpy` package to start a session that vscode can connect to:
+
+```
+python -m debugpy --wait-for-client --listen 0.0.0.0:5678 script.py
+```
+
+Example for octo:
+```
+python -m debugpy --wait-for-client --listen 0.0.0.0:5678 examples/02_finetune_new_observation_action.py --pretrained_path=hf://rail-berkeley/octo-small --data_dir=...
+```
+
+Then in vscode, create a `launch.json` configuration for "Python Debugger: Remote Attach", e.g.
+```json
+{
+    "configurations": [
+        {
+            "name": "Python Debugger: Remote Attach",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ]
+        },
+    ]
+}
+```

--- a/docker/Singularity
+++ b/docker/Singularity
@@ -1,0 +1,40 @@
+Bootstrap: docker
+From: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+
+%post
+        apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        wget \
+        gnupg \
+        python3-pip \
+        python3-dev \
+        python-is-python3 \
+        git \
+        ffmpeg \
+        libnvidia-gl-560 \
+        libvulkan1 \
+        vulkan-tools \
+        software-properties-common
+        
+        apt-get clean
+        rm -rf /var/lib/apt/lists/*
+
+        mkdir /project && cd /project
+
+        # Install octo/SimplerEnv python requirements
+        wget https://raw.githubusercontent.com/simpler-env/SimplerEnv/refs/heads/main/requirements_full_install.txt
+        pip install tensorflow==2.15.0
+        pip install -r requirements_full_install.txt && rm requirements_full_install.txt
+        pip install tensorflow[and-cuda]==2.15.1 
+        pip install git+https://github.com/nathanrooy/simulated-annealing 
+        pip install numpy==1.24.4 
+        pip install --upgrade "jax[cuda11_pip]==0.4.20" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+        # Upgrade pip so we can install SimplerEnv later
+        pip3 install -U pip
+
+%environment
+        SHELL=/bin/bash
+        export SHELL
+        export NVIDIA_DRIVER_CAPABILITIES=all
+
+%runscript
+        exec /bin/sh "$@"

--- a/docker/Singularity
+++ b/docker/Singularity
@@ -14,7 +14,7 @@ From: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
         libvulkan1 \
         vulkan-tools \
         software-properties-common
-        
+
         apt-get clean
         rm -rf /var/lib/apt/lists/*
 
@@ -22,8 +22,10 @@ From: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 
         # Install octo/SimplerEnv python requirements
         wget https://raw.githubusercontent.com/simpler-env/SimplerEnv/refs/heads/main/requirements_full_install.txt
+        wget https://raw.githubusercontent.com/simpler-env/ManiSkill2_real2sim/cd45dd27dc6bb26d048cb6570cdab4e3f935cc37/requirements.txt
         pip install tensorflow==2.15.0
         pip install -r requirements_full_install.txt && rm requirements_full_install.txt
+        pip install -r requirements.txt && rm requirements.txt
         pip install tensorflow[and-cuda]==2.15.1 
         pip install git+https://github.com/nathanrooy/simulated-annealing 
         pip install numpy==1.24.4 


### PR DESCRIPTION
You can use a pre-built singularity container in `/home/mila/a/artur.kuramshin/scratch/octo_simplerenv.simg`

## Testing
Ran the following command to test octo fine-tunning: 
```
python examples/02_finetune_new_observation_action.py --pretrained_path=hf://rail-berkeley/octo-small-1.5 --data_dir=/project/aloha_sim_dataset
```
Ran the following command to test SimplerEnv:
```
python simpler_env/simple_inference_visual_matching_prepackaged_envs.py --policy octo-small \
        --ckpt-path None --task widowx_spoon_on_towel  --logging-root ./results_simple_eval/  --n-trajs 10
```
