### PR TITLE
Fix gradient accumulation & resize before shuffle_buffer_size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ wandb
 .vscode
 .idea
 datasets/debug_dataset/bridge_dataset/1.0.0/action_*
+*.out

--- a/octo/data/dataset.py
+++ b/octo/data/dataset.py
@@ -577,10 +577,12 @@ def make_interleaved_dataset(
     # interleave at the frame level and then shuffle
     dataset: dl.DLataset = dl.DLataset.sample_from_datasets(
         datasets, sample_weights
-    ).shuffle(shuffle_buffer_size)
+    )
 
     # apply frame transforms
     dataset = apply_frame_transforms(dataset, **frame_transform_kwargs, train=train)
+
+    dataset = dataset.shuffle(shuffle_buffer_size)
 
     # sequential batch (parallel batch seems to use much more memory)
     if batch_size is not None:

--- a/octo/utils/train_utils.py
+++ b/octo/utils/train_utils.py
@@ -321,7 +321,7 @@ def create_optimizer(
     grad_accumulation_steps = kwargs.pop("grad_accumulation_steps", None)
 
     tx = optax.adamw(mu_dtype=jnp.bfloat16, **kwargs, mask=wd_mask)
-    if grad_accumulation_steps:
+    if grad_accumulation_steps and grad_accumulation_steps > 1:
         tx = optax.MultiSteps(tx, grad_accumulation_steps)
     if clip_gradient is not None:
         tx = optax.chain(

--- a/scripts/configs/octo_mini_pretrain_config.py
+++ b/scripts/configs/octo_mini_pretrain_config.py
@@ -104,12 +104,21 @@ def get_config(config_string=None):
         "wrist": wrist_augment_kwargs,
     }
 
+    grad_accumulation_steps = 2
     config = update_config(
         config,
-        num_steps=3000,
+        num_steps=300000,
         window_size=2,
         optimizer=dict(
             frozen_keys=("*hf_model*",),
+            learning_rate=dict(
+                    name="rsqrt",
+                    init_value=0.0,
+                    peak_value=3e-4,
+                    warmup_steps=2000 * grad_accumulation_steps,
+                    timescale=10000 * grad_accumulation_steps,
+                ),
+            grad_accumulation_steps=grad_accumulation_steps,
         ),
         dataset_kwargs=dict(
             oxe_kwargs=dict(
@@ -129,8 +138,8 @@ def get_config(config_string=None):
                     rephrase_prob=0.5,
                 ),
             ),
-            batch_size=16,
-            shuffle_buffer_size=10000,
+            batch_size=512 // grad_accumulation_steps,
+            shuffle_buffer_size=500000,
             balance_weights=True,
         ),
         text_processor=ModuleSpec.create(
@@ -151,9 +160,9 @@ def get_config(config_string=None):
             ),
         ),
         eval_datasets=["bridge_dataset"],
-        log_interval=500,
-        eval_interval=500,
-        viz_interval=500,
+        log_interval=200,
+        eval_interval=1000,
+        viz_interval=5000,
         save_interval=1000,
     )
 

--- a/scripts/configs/octo_mini_pretrain_config.py
+++ b/scripts/configs/octo_mini_pretrain_config.py
@@ -104,7 +104,7 @@ def get_config(config_string=None):
         "wrist": wrist_augment_kwargs,
     }
 
-    grad_accumulation_steps = 2
+    grad_accumulation_steps = 1
     config = update_config(
         config,
         num_steps=300000,
@@ -139,7 +139,7 @@ def get_config(config_string=None):
                 ),
             ),
             batch_size=512 // grad_accumulation_steps,
-            shuffle_buffer_size=500000,
+            shuffle_buffer_size=int(5e5),
             balance_weights=True,
         ),
         text_processor=ModuleSpec.create(
@@ -161,9 +161,9 @@ def get_config(config_string=None):
         ),
         eval_datasets=["bridge_dataset"],
         log_interval=200,
-        eval_interval=1000,
-        viz_interval=5000,
-        save_interval=1000,
+        eval_interval=5000,
+        viz_interval=20000,
+        save_interval=10000,
     )
 
     return config

--- a/scripts/train_mini.py
+++ b/scripts/train_mini.py
@@ -213,7 +213,7 @@ def main(_):
         train_state = save_callback.state_checkpointer.restore(
             save_callback.state_checkpointer.latest_step(), items=train_state
         )
-        checkpoint_step = int(train_state.step)
+        checkpoint_step = int(train_state.step) // FLAGS.config.optimizer.grad_accumulation_steps
         logging.info("Restored checkpoint from %s", save_dir)
         if FLAGS.config.start_step is not None:
             start_step = FLAGS.config.start_step  # start_step overrides checkpoint


### PR DESCRIPTION
I share my changes here:
 - Fix gradient accumulation (however I am not using it anymore as I am doing experiments on `short-unkillable`)
 - Move the resizing of images before shuffling to save CPU memory. 
   This is specific for testing smaller images, as the images saved on the disk are 256x256. If we find the shape we aim to use, we may want to save on disk the images with the right shape and then restore the order of shuffling/image processing.